### PR TITLE
Update graphql-parser to the latest upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,3 @@ members = [
     "agora",
     "node-plugin/native",
 ]
-
-[patch.crates-io]
-# Include the consume_query API
-graphql-parser = { git = "https://github.com/That3Percent/graphql-parser.git", rev = "d2225bd38d529e9d39d51bdf6dbf189bdf0923aa" }

--- a/node-plugin/lang/Cargo.toml
+++ b/node-plugin/lang/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Include the consume_query API
-graphql-parser = { git = "https://github.com/That3Percent/graphql-parser.git", rev = "d2225bd38d529e9d39d51bdf6dbf189bdf0923aa" }
+# Include the consume_definition API and nameless operations fix
+graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser", rev = "8a759df" }
 # graphql-parser = "0.3.0"
 nom = "5.1.2"
 num-bigint = "0.2.6"

--- a/node-plugin/lang/src/parser.rs
+++ b/node-plugin/lang/src/parser.rs
@@ -4,7 +4,7 @@ use crate::parse_errors::{
 use crate::prelude::*;
 use crate::{expressions::*, language::*, parse_errors::*};
 use fraction::BigFraction;
-use graphql_parser::{consume_query, query as q};
+use graphql_parser::query as q;
 use nom::{
     branch::alt,
     bytes::complete::{is_not, take_while1},
@@ -29,7 +29,7 @@ fn graphql_query<'a>(input: &'a str) -> IResult<&'a str, q::Field<'a, &'a str>> 
     with_context(ErrorContext::GraphQLQuery, |input: &str| {
         tag("query")(input)?;
         fail_fast(|input: &'a str| {
-            let (query, input) = consume_query::<'a, &'a str>(input)
+            let (query, input) = q::consume_definition::<'a, &'a str>(input)
                 .map_err(|e| ErrAtom::new(input, ValidationError::FailedToParseGraphQL(e)))?;
 
             let query = match query {


### PR DESCRIPTION
All changes we need (`consume_definition` and protection against stack overflows) have been merged. On top of that, the latest upstream fixes an issue where parsing a query with a nameless operation with variables (like `query ($id: ID!) { ... }`) is serialized to `query { ... }`, incorrectly dropping the variable definitions.