### PR TITLE
Fix build for Node v16

### DIFF
--- a/node-plugin/native/Cargo.toml
+++ b/node-plugin/native/Cargo.toml
@@ -12,8 +12,8 @@ name = "node_plugin"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-neon-build = "0.5.0"
+neon-build = "0.8.3"
 
 [dependencies]
-neon = "0.5.0"
+neon = "0.8.3"
 cost-model = { path = "../lang" }


### PR DESCRIPTION
When using node v16, the neon-sys dependency fails to build. This is resolved by bumping the required version up to 0.8.3 (this bug was [fixed](https://github.com/neon-bindings/neon/pull/715) in version 0.8.1).