### PR TITLE
Improve precompiled binary compatibility

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
         system:
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-latest
+          - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
         include:
           - node_version: 16

--- a/node-plugin/package.json
+++ b/node-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/cost-model",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Cost model",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/node-plugin/package.json
+++ b/node-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/cost-model",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Cost model",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/node-plugin/package.json
+++ b/node-plugin/package.json
@@ -5,7 +5,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "/lib"
+    "/lib",
+    "/src",
+    "Cargo.toml"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Include .rs files in NPM package, so machines not compatible with precompiled binaries can still build the package without cloning from source. 
- Use ubuntu-18.04 machine to precompile packages to improve compatibility with linux distributions.