### PR TITLE
workflows: Build binaries for Node v18 (node-abi = v108)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       # (https://github.com/bchr02/node-pre-gyp-github/issues/42)
       fail-fast: false
       matrix:
-        node_version: [12, 14, 16, 17]
+        node_version: [14, 16, 17, 18]
         system:
           - os: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
Towards better support for Node v18 (current node LTS is 18.13.0).