### PR TITLE
chore: update toolshed version

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -16,4 +16,4 @@ fraction = { version = "0.6.3", features = ["with-bigint"] }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0"
 single = "1.0.0"
-toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.1" }
+toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.2" }


### PR DESCRIPTION
Update `cost-model`'s `toolshed` dependency version to `v0.2.2`.