### PR TITLE
chore(cost-model): use graphql crate instead of toolshed

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+firestorm = "0.5"
+fraction = { version = "0.6.3", features = ["with-bigint"] }
+graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.1.0", default-features = false }
 lazy_static = "1.4.0"
 nom = "5.1.2"
 num-bigint = "0.2.6"
 num-traits = "0.2.12"
-firestorm = "0.5"
-fraction = { version = "0.6.3", features = ["with-bigint"] }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0"
 single = "1.0.0"
-toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.2" }

--- a/lang/src/coercion.rs
+++ b/lang/src/coercion.rs
@@ -1,6 +1,6 @@
 use fraction::BigFraction;
 use q::Value::*;
-use toolshed::graphql::graphql_parser::query as q;
+use graphql::graphql_parser::query as q;
 
 /// This is like TryInto, but more liberal
 pub trait Coerce<T> {

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{Captures, CostError};
-use toolshed::graphql::{graphql_parser::query as q, QueryVariables};
+use graphql::{graphql_parser::query as q, QueryVariables};
 
 pub struct Context<'a, T: q::Text<'a>> {
     pub operations: Vec<q::OperationDefinition<'a, T>>,

--- a/lang/src/expressions/primitives.rs
+++ b/lang/src/expressions/primitives.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::coercion::Coerce;
 use std::marker::PhantomData;
-use toolshed::graphql::StaticValue;
+use graphql::StaticValue;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 struct Unowned<T>(PhantomData<*const T>);

--- a/lang/src/language.rs
+++ b/lang/src/language.rs
@@ -5,7 +5,7 @@ use crate::matching::{get_capture_names_field, match_query};
 use crate::prelude::*;
 use fraction::BigFraction;
 use std::collections::HashMap;
-use toolshed::graphql::{graphql_parser::query as q, IntoStaticValue, QueryVariables, StaticValue};
+use graphql::{graphql_parser::query as q, IntoStaticValue, QueryVariables, StaticValue};
 
 #[derive(Debug, PartialEq)]
 pub struct Document<'a> {

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -17,8 +17,8 @@ use fraction::{BigFraction, GenericFraction, Sign};
 use language::*;
 use num_bigint::BigUint;
 use std::{error, fmt};
-use toolshed::graphql::graphql_parser::query as q;
-use toolshed::graphql::QueryVariables;
+use graphql::graphql_parser::query as q;
+use graphql::QueryVariables;
 
 pub use context::Context;
 

--- a/lang/src/matching.rs
+++ b/lang/src/matching.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use single::Single as _;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
-use toolshed::graphql::{graphql_parser::query as q, IntoStaticValue, QueryVariables};
+use graphql::{graphql_parser::query as q, IntoStaticValue, QueryVariables};
 
 struct MatchingContext<'var, 'cap, 'frag, 'fragt: 'frag, TF: q::Text<'fragt>> {
     fragments: &'frag [q::FragmentDefinition<'fragt, TF>],

--- a/lang/src/parse_errors.rs
+++ b/lang/src/parse_errors.rs
@@ -4,7 +4,7 @@ use nom::{Err as NomErr, IResult, InputLength};
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Deref;
-use toolshed::graphql::graphql_parser::query::ParseError as GraphQLParseError;
+use graphql::graphql_parser::query::ParseError as GraphQLParseError;
 
 /// If something failed, this notes what we were
 /// trying to do when it failed.

--- a/lang/src/parser.rs
+++ b/lang/src/parser.rs
@@ -18,7 +18,7 @@ use nom::{
 use num_bigint::BigUint;
 use num_traits::Pow as _;
 use single::Single as _;
-use toolshed::graphql::graphql_parser::query as q;
+use graphql::graphql_parser::query as q;
 
 // Change Nom default error type from (I, ErrorKind) to ErrorAggregator<I>
 type IResult<I, O, E = ErrorAggregator<I>> = NomIResult<I, O, E>;


### PR DESCRIPTION
Splitting the graphql parsing logic into its own crate now allows evolving the `toolshed` crate independently.