### PR TITLE
fix(lang): reexport QueryVariables type

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -18,7 +18,7 @@ use language::*;
 use num_bigint::BigUint;
 use std::{error, fmt};
 use graphql::graphql_parser::query as q;
-use graphql::QueryVariables;
+pub use graphql::QueryVariables;
 
 pub use context::Context;
 


### PR DESCRIPTION
By reexporting the `grapqhql` crate's `QueryVariables` type, we fix the `graph-gateway` "dependency hell" issue that forces to upgrade at the same time the `graphql` crate and the `cost-model`.