### PR TITLE
Fix local fallback compile of native binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "arm64"
   ],
   "scripts": {
-    "build": "cargo-cp-artifact -a cdylib node_plugin ./node-plugin/native/index.node -- cargo build --message-format=json-render-diagnostics",
+    "build": "cargo-cp-artifact -a cdylib node_plugin ./node-plugin/native/index.node -- cargo build --manifest-path ./node-plugin/Cargo.toml --message-format=json-render-diagnostics",
     "build-debug": "yarn build --",
     "build-release": "yarn build --release",
     "package": "node-pre-gyp package",


### PR DESCRIPTION
### Changes
- Use explicit manifest path to compile node-plugin crate binary. 