### PR TITLE
Add macos aarch64

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,14 +19,15 @@ jobs:
         system:
           - os: macos-12
             target: x86_64-apple-darwin
+          - os: macos-13-xlarge
+            target: aarch64-apple-darwin
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
         include:
-          ## ARM64 builds are not working. No ARM64 GitHub Action runners available out of box. Need to nail down cross compile
-          # - node_version: 16
-          #  system:
-          #    os: macos-latest
-          #   target: aarch64-apple-darwin
+          - node_version: 16
+            system:
+              os: macos-13-xlarge
+              target: aarch64-apple-darwin
           - node_version: 17
             system:
               os: ubuntu-20.04

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
         include:
-          - node_version: 16
+          - node_version: 17
             system:
               os: macos-13-xlarge
               target: aarch64-apple-darwin


### PR DESCRIPTION
Github enabled ARM M1 chips in Actions.

https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/