### PR TITLE
feat: allow to create contexts with a static lifetime

### DIFF
--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -25,6 +25,29 @@ impl<'a, T: q::Text<'a>> Context<'a, T> {
     }
 }
 
+impl Context<'static, String> {
+    /// Create a context whose lifetime does not depend on its inputs.
+    ///
+    /// This is useful in situations where the context is kept around beyond the
+    /// lifetime of the input query and variables.
+    pub fn new_static(query: &str, variables: &str) -> Result<Self, CostError> {
+        profile_method!(new_static);
+
+        let parsed_variables =
+            crate::parse_vars(&variables).map_err(|_| CostError::FailedToParseVariables)?;
+        let query = q::parse_query(&query)
+            .map_err(|_| CostError::FailedToParseQuery)?
+            .into_static();
+        let (operations, fragments) = crate::split_definitions(query.definitions);
+
+        Ok(Self {
+            variables: parsed_variables,
+            fragments,
+            operations,
+        })
+    }
+}
+
 impl<'a, T: q::Text<'a> + Clone> Clone for Context<'a, T> {
     fn clone(&self) -> Self {
         Self {


### PR DESCRIPTION
This is useful in situations where the context is kept around beyond the lifetime of the input query and variables.